### PR TITLE
feat: consider bank holiday for the Coronation of King Charles III

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "definitions"]
 	path = definitions
-	url = https://github.com/holidays/definitions
+	url = https://github.com/Seedrs/holidays-definitions


### PR DESCRIPTION
## What does this PR do?
As per https://github.com/Seedrs/holidays-definitions/pull/1, on the 8th of May 2023, there will be a bank holiday for the Coronation of King Charles III.

## External context (JIRA)
[PHEALTH-997](https://seedrs.atlassian.net/browse/PHEALTH-997)

## Deploy plan
Merge with master

[PHEALTH-997]: https://seedrs.atlassian.net/browse/PHEALTH-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ